### PR TITLE
generate targets.json and deploy into repo

### DIFF
--- a/.github/workflows/build-distro.yml
+++ b/.github/workflows/build-distro.yml
@@ -224,6 +224,24 @@ jobs:
           ls ./build-${{ matrix.machine }}/build/tmp/deploy/rpm
           ./repo/stage-rpms.sh ./build-${{ matrix.machine }}/build/tmp/deploy/rpm ${{ env.STAGING_PATH }} ${{ needs.determine_build_matrix.outputs.distro_codename }}
 
+      - name: Generate target fragment for ${{ matrix.machine }}
+        if: matrix.build_config.target == 'avocado-distro'
+        run: |
+          echo "Generating target fragment for ${{ matrix.machine }}"
+
+          # Create fragments directory in staging base path
+          FRAGMENTS_DIR="${{ env.STAGING_BASE_PATH }}/fragments"
+          mkdir -p "$FRAGMENTS_DIR"
+
+          # Generate the target fragment using the repo map
+          ./repo/generate-target-fragment.sh \
+            ./build-${{ matrix.machine }}/build/tmp/deploy/rpm \
+            ${{ matrix.machine }} \
+            "$FRAGMENTS_DIR" \
+            ${{ needs.determine_build_matrix.outputs.distro_codename }}
+
+          echo "Target fragment generated for ${{ matrix.machine }}"
+
   validate_staging_checksums:
     needs:
       - determine_build_matrix
@@ -332,3 +350,29 @@ jobs:
           echo "Writing metadata to: ${{ env.RELEASES_PATH }}"
           echo "Metadata will use relative paths to packages"
           ./repo/update-metadata-distro.sh "${{ env.PACKAGES_PATH }}" "" "${{ env.RELEASES_PATH }}"
+
+      - name: Generate targets.json file
+        run: |
+          echo "Generating targets.json file"
+          echo "Aggregating target fragments from: ${{ env.STAGING_BASE_PATH }}/fragments"
+          echo "Output file: ${{ env.RELEASES_PATH }}/targets.json"
+
+          # Check for existing targets.json in the staging directory (persistent across builds)
+          STAGING_PERSISTENT_DIR="$(dirname ${{ env.STAGING_BASE_PATH }})/${{ env.DISTRO_CODENAME }}"
+          EXISTING_TARGETS_FILE="$STAGING_PERSISTENT_DIR/targets.json"
+
+          if [ -f "$EXISTING_TARGETS_FILE" ] && [ -s "$EXISTING_TARGETS_FILE" ]; then
+            echo "Found existing targets.json: $EXISTING_TARGETS_FILE"
+            echo "Will merge with existing targets to preserve all available targets"
+            ./repo/aggregate-targets.sh "${{ env.STAGING_BASE_PATH }}/fragments" "${{ env.RELEASES_PATH }}/targets.json" "$EXISTING_TARGETS_FILE"
+          else
+            echo "No existing targets.json found, creating new file"
+            ./repo/aggregate-targets.sh "${{ env.STAGING_BASE_PATH }}/fragments" "${{ env.RELEASES_PATH }}/targets.json"
+          fi
+
+          # Update the persistent targets.json in staging directory for future builds
+          echo "Updating persistent targets.json in staging directory"
+          mkdir -p "$STAGING_PERSISTENT_DIR"
+          cp "${{ env.RELEASES_PATH }}/targets.json" "$EXISTING_TARGETS_FILE"
+
+          echo "targets.json generation complete"

--- a/repo/aggregate-targets.sh
+++ b/repo/aggregate-targets.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+# Script to aggregate target-specific JSON fragments into a complete targets.json file
+# This script combines individual target fragments created during the build process
+# into a single targets.json file for deployment.
+#
+# The script supports merging with existing targets.json files to handle cases where
+# only a subset of targets are built (e.g., single machine workflow dispatch).
+
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <fragments-directory> <output-file> [existing-targets-json]"
+    echo "Example: $0 /path/to/staging/fragments /path/to/releases/targets.json"
+    echo "Example: $0 /path/to/staging/fragments /path/to/releases/targets.json /path/to/existing/targets.json"
+    echo ""
+    echo "If existing-targets-json is provided, new fragments will be merged with existing targets."
+    echo "If not provided, the script will look for an existing targets.json at the output location."
+    exit 1
+fi
+
+FRAGMENTS_DIR=$1
+OUTPUT_FILE=$2
+EXISTING_TARGETS_FILE=${3:-$OUTPUT_FILE}
+
+echo "Aggregating target fragments from: ${FRAGMENTS_DIR}"
+echo "Output file: ${OUTPUT_FILE}"
+
+# Check if fragments directory exists
+if [ ! -d "${FRAGMENTS_DIR}" ]; then
+    echo "Error: Fragments directory not found at ${FRAGMENTS_DIR}" >&2
+    exit 1
+fi
+
+# Create output directory if it doesn't exist
+OUTPUT_DIR=$(dirname "${OUTPUT_FILE}")
+mkdir -p "${OUTPUT_DIR}"
+
+# Read existing targets.json if it exists
+existing_targets=()
+if [ -f "$EXISTING_TARGETS_FILE" ] && [ -s "$EXISTING_TARGETS_FILE" ]; then
+    echo "Found existing targets file: $EXISTING_TARGETS_FILE"
+    
+    # Extract existing targets using jq if available, otherwise use basic parsing
+    if command -v jq >/dev/null 2>&1; then
+        # Use jq to extract key-value pairs
+        while IFS= read -r target_entry; do
+            if [ -n "$target_entry" ]; then
+                existing_targets+=("$target_entry")
+            fi
+        done < <(jq -r 'to_entries[] | "\(.key):\(.value | @json)"' "$EXISTING_TARGETS_FILE" 2>/dev/null || true)
+    else
+        echo "Warning: jq not available, using basic JSON parsing"
+        # Basic parsing - extract content between outer braces
+        existing_content=$(cat "$EXISTING_TARGETS_FILE" | sed 's/^{//' | sed 's/}$//')
+        if [ -n "$existing_content" ] && [ "$existing_content" != "{}" ]; then
+            existing_targets+=("$existing_content")
+        fi
+    fi
+    
+    echo "Found ${#existing_targets[@]} existing target(s)"
+else
+    echo "No existing targets file found or file is empty"
+fi
+
+# Find all fragment files
+fragment_files=($(find "${FRAGMENTS_DIR}" -name "*-fragment.json" -type f | sort))
+
+if [ ${#fragment_files[@]} -eq 0 ]; then
+    if [ ${#existing_targets[@]} -eq 0 ]; then
+        echo "Warning: No fragment files found and no existing targets"
+        echo "Creating empty targets.json file"
+        echo "{}" > "${OUTPUT_FILE}"
+        exit 0
+    else
+        echo "No new fragments found, preserving existing targets"
+        # Reconstruct from existing targets
+        printf "{" > "${OUTPUT_FILE}"
+        first_target=true
+        for target_entry in "${existing_targets[@]}"; do
+            if [ "$first_target" = false ]; then
+                printf "," >> "${OUTPUT_FILE}"
+            fi
+            first_target=false
+            printf '%s' "$target_entry" >> "${OUTPUT_FILE}"
+        done
+        printf "}" >> "${OUTPUT_FILE}"
+        echo "Preserved existing targets.json"
+        exit 0
+    fi
+fi
+
+echo "Found ${#fragment_files[@]} new fragment files:"
+for file in "${fragment_files[@]}"; do
+    echo "  - $(basename "$file")"
+done
+
+# Collect new targets from fragments
+new_targets=()
+new_target_names=()
+
+for fragment_file in "${fragment_files[@]}"; do
+    echo "Processing fragment: $(basename "$fragment_file")"
+    
+    # Validate fragment file is not empty
+    if [ ! -s "$fragment_file" ]; then
+        echo "  Warning: Fragment file is empty: $fragment_file"
+        continue
+    fi
+    
+    # Extract the content between the outer braces (works with both compact and formatted JSON)
+    # Remove the outer { and } and extract the key-value pair
+    fragment_content=$(cat "${fragment_file}" | sed 's/^{//' | sed 's/}$//')
+    
+    # Extract target name for duplicate detection
+    target_name=$(echo "$fragment_content" | sed 's/^\"\([^\"]*\)\".*/\1/')
+    
+    # Debug: show what we're adding
+    echo "  Target: $target_name"
+    echo "  Adding content: ${fragment_content:0:100}$([ ${#fragment_content} -gt 100 ] && echo "...")"
+    
+    new_targets+=("$fragment_content")
+    new_target_names+=("$target_name")
+done
+
+# Start building the aggregated JSON (compact format)
+printf "{" > "${OUTPUT_FILE}"
+
+# Add existing targets first (excluding any that are being updated by new fragments)
+first_entry=true
+for target_entry in "${existing_targets[@]}"; do
+    # Extract target name from existing entry
+    existing_target_name=$(echo "$target_entry" | sed 's/^\"\([^\"]*\)\".*/\1/')
+    
+    # Check if this target is being updated by a new fragment
+    target_being_updated=false
+    for new_target_name in "${new_target_names[@]}"; do
+        if [ "$existing_target_name" = "$new_target_name" ]; then
+            target_being_updated=true
+            echo "Updating existing target: $existing_target_name"
+            break
+        fi
+    done
+    
+    # Only add existing target if it's not being updated
+    if [ "$target_being_updated" = false ]; then
+        if [ "$first_entry" = false ]; then
+            printf "," >> "${OUTPUT_FILE}"
+        fi
+        first_entry=false
+        printf '%s' "$target_entry" >> "${OUTPUT_FILE}"
+        echo "Preserving existing target: $existing_target_name"
+    fi
+done
+
+# Add new/updated targets from fragments
+for target_content in "${new_targets[@]}"; do
+    if [ "$first_entry" = false ]; then
+        printf "," >> "${OUTPUT_FILE}"
+    fi
+    first_entry=false
+    printf '%s' "$target_content" >> "${OUTPUT_FILE}"
+done
+
+# Close the JSON object
+printf "}" >> "${OUTPUT_FILE}"
+
+echo "Aggregation complete!"
+total_targets=$((${#existing_targets[@]} + ${#new_targets[@]} - ${#new_target_names[@]}))
+echo "Generated targets.json with $total_targets total targets:"
+echo "  - ${#existing_targets[@]} existing targets (${#new_target_names[@]} updated)"
+echo "  - ${#new_targets[@]} new/updated targets from fragments"
+
+# Validate the generated JSON
+if command -v jq >/dev/null 2>&1; then
+    echo "Validating generated JSON..."
+    if jq empty "${OUTPUT_FILE}" 2>/dev/null; then
+        echo "✓ Generated JSON is valid"
+        echo "Preview of generated targets.json (formatted for readability):"
+        jq . "${OUTPUT_FILE}" | head -20
+        if [ $(jq . "${OUTPUT_FILE}" | wc -l) -gt 20 ]; then
+            echo "... (truncated)"
+        fi
+        echo ""
+        echo "Compact size: $(wc -c < "${OUTPUT_FILE}") bytes"
+    else
+        echo "✗ Generated JSON is invalid" >&2
+        echo "Raw content:"
+        cat "${OUTPUT_FILE}"
+        exit 1
+    fi
+else
+    echo "Note: jq not available for JSON validation"
+    echo "Raw compact JSON:"
+    cat "${OUTPUT_FILE}"
+    echo ""
+    echo "Size: $(wc -c < "${OUTPUT_FILE}") bytes"
+fi
+
+echo "Targets aggregation complete!"

--- a/repo/generate-target-fragment.sh
+++ b/repo/generate-target-fragment.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+# Script to generate a target-specific JSON fragment for targets.json
+# This script analyzes the avocado-repo.map file to determine which repositories
+# a specific target uses and creates a JSON fragment for that target.
+
+if [ $# -ne 4 ]; then
+    echo "Usage: $0 <source-deploy-directory> <target-name> <output-directory> <releasever>"
+    echo "Example: $0 /path/to/build/tmp/deploy/rpm qemux86-64 /path/to/staging latest/apollo/edge"
+    exit 1
+fi
+
+SOURCE_DEPLOY_DIR=$1
+TARGET_NAME=$2
+OUTPUT_DIR=$3
+releasever=$4
+
+MAP_FILE="${SOURCE_DEPLOY_DIR}/avocado-repo.map"
+
+if [ ! -f "${MAP_FILE}" ]; then
+    echo "Error: Map file not found at ${MAP_FILE}" >&2
+    exit 1
+fi
+
+echo "Generating target fragment for: ${TARGET_NAME}"
+echo "Using map file: ${MAP_FILE}"
+echo "Output directory: ${OUTPUT_DIR}"
+echo "Release version: ${releasever}"
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+# Initialize the repositories array
+repos=()
+
+# Process mappings from the map file to collect repository paths
+while IFS='=' read -r key value || [ -n "$key" ]; do   
+    # Skip empty lines or lines without an equals sign
+    if [ -z "$key" ] || [ -z "$value" ]; then
+        continue
+    fi
+    
+    # Expand variables in the value (like $releasever)
+    expanded_value=$(eval "echo \"${value}\"")
+    
+    # Convert absolute path to relative path by removing the releasever prefix
+    # This makes paths relative to the targets.json file location
+    relative_path="${expanded_value#${releasever}/}"
+    
+    source_dir="${SOURCE_DEPLOY_DIR}/${key}"
+    
+    # Only include repositories that actually exist and have packages
+    if [ -d "${source_dir}" ] && [ -n "$(find "${source_dir}" -name "*.rpm" -print -quit)" ]; then
+        echo "Found packages in: ${source_dir} -> ${relative_path}"
+        repos+=("\"${relative_path}\"")
+    fi
+done < "${MAP_FILE}"
+
+# Always add the target-specific extension repository (relative path)
+target_ext_repo="target/${TARGET_NAME}-ext"
+repos+=("\"${target_ext_repo}\"")
+echo "Added extension repository: ${target_ext_repo}"
+
+# Generate JSON fragment (compact format)
+fragment_file="${OUTPUT_DIR}/${TARGET_NAME}-fragment.json"
+
+# Create the JSON structure (compact, no unnecessary whitespace)
+printf '{"' > "${fragment_file}"
+printf '%s":[' "${TARGET_NAME}" >> "${fragment_file}"
+
+# Add repositories with minimal spacing
+first_repo=true
+for repo in "${repos[@]}"; do
+    if [ "$first_repo" = false ]; then
+        printf "," >> "${fragment_file}"
+    fi
+    first_repo=false
+    printf '%s' "$repo" >> "${fragment_file}"
+done
+
+printf ']}' >> "${fragment_file}"
+
+echo "Generated target fragment: ${fragment_file}"
+echo "Repositories for ${TARGET_NAME}:"
+for repo in "${repos[@]}"; do
+    echo "  - $(echo "$repo" | tr -d '"')"
+done
+
+echo "Target fragment generation complete!"


### PR DESCRIPTION
Deploy static information about what targets were built in a release and which relative repositories that target's SDK would interface with. This information is deployed in the repo at 

```
<codename>/targets.json
releases/<codename>/date/targets.json
```
The file will be structured:
```
{
  "qemux86-64": [
    "sdk/all",
    "sdk/qemu86-64",
    "target/qemux86-64",
    "target/noarch",
    "target/core2_64"
  ],
  "qemuarm64": [
    "sdk/all",
    "sdk/qemuarm64",
    "target/qemuarm64",
    "target/noarch",
    "target/aarch64"
  ],
  "<target name>": [
    "<repo>"
  ]
}
```
The top level keys are target names and the paths in the list value are relative paths to target relevant repos relative to the `targets.json` file.

These updates will also keep a rolling copy of this information to support workflow dispatch jobs where only a single or subset of targets are being built to prevent it from "removing" targets that were not part of a single build. 