### PR TITLE
Added generic cog service for more targets like rpis

### DIFF
--- a/extensions/webkit/avocado.yaml
+++ b/extensions/webkit/avocado.yaml
@@ -37,6 +37,8 @@ extensions:
       wpebackend-fdo: '*'
       wpewebkit: '*'
 
+    overlay: overlays/base
+
     reterminal:
       overlay: overlays/reterminal
 

--- a/extensions/webkit/overlays/base/usr/lib/systemd/system/cog.service
+++ b/extensions/webkit/overlays/base/usr/lib/systemd/system/cog.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Cog Webkit Launcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/cog-avocado
+
+Environment=COG_URL=https://avocadolinux.org
+Environment=XDG_RUNTIME_DIR=/run/user/0
+Environment=HOME=/tmp
+
+ExecStartPre=/bin/sh -c "mkdir -p /run/user/0"
+ExecStartPre=/bin/sh -c "cat /usr/share/ca-certificates/mozilla/*.crt > /etc/ssl/certs/ca-certificates.crt"
+
+ExecStart=/usr/bin/cog --platform-params='renderer=gles' ${COG_URL}
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add generic cog.service for all webkit targets" --body "Adds a base overlay with a generic cog.service that works on RPi4, RPi5. Have not tested with Jetson, x86, etc. 
Previously only reTerminal and reTerminal-DM had service files, so cog would not start on other targets.                                   

Includes XDG_RUNTIME_DIR, writable HOME for shader cache, and GLES renderer. 
No rotation (reTerminal overlays still override with rotation=3).