### PR TITLE
bsp/grinn-astra-1680-sbc: add additional gpu drivers

### DIFF
--- a/bsp/grinn-astra-1680-sbc/avocado.yaml
+++ b/bsp/grinn-astra-1680-sbc/avocado.yaml
@@ -45,6 +45,8 @@ extensions:
       kernel-module-syna-drm: '*'
       kernel-module-drm-ttm-helper: '*'
       kernel-module-ttm: '*'
+      synasdk-gpu-pvr: "*"
+      mesa-megadriver: "*"
       # --- Audio (Synaptics Berlin) ---
       kernel-module-snd-soc-berlin-asoc: '*'
       kernel-module-snd-soc-berlin-pcm: '*'


### PR DESCRIPTION
Add additional GPU drivers to the BSP. This will make the BSP more generic. One package contains the GPU kernel driver (synasdk-gpu-pvr) and the other contains the GPU's user space component (mesa-megadriver). By contrast, the pvrsrvkm and syna-drm drivers only provide support for the DRM/KMS part of the GPU, not the actual 3D acceleration.