### PR TITLE
Fix/grow var luks support

### DIFF
--- a/extensions/dev/overlays/base/usr/bin/avocado-grow-var
+++ b/extensions/dev/overlays/base/usr/bin/avocado-grow-var
@@ -24,14 +24,23 @@ fi
 var_dev=$(findmnt -no SOURCE /var)
 
 # Resolve through any device-mapper layer (e.g. LUKS) to the real block
-# partition.  lsblk -l lists all devices in the dependency tree of the given
-# device; selecting the first entry typed "part" gives the underlying
-# partition regardless of how many dm layers sit above it.
-blk_dev=$(lsblk -lno NAME,TYPE "$var_dev" 2>/dev/null \
-          | awk '$2 == "part" { print "/dev/" $1; exit }')
-: "${blk_dev:=$var_dev}"
+# partition.  For dm devices, read sysfs slaves — lsblk does not recurse
+# into dm dependency trees when given a mapper path directly.
+# Handles both /dev/mapper/<name> and /dev/dm-N forms (findmnt may return
+# either depending on whether udev has created the mapper symlink yet).
+blk_dev=$var_dev
+dm_dev=""
+case "$var_dev" in
+/dev/mapper/*) dm_dev=$(basename "$(readlink "$var_dev")") ;;
+/dev/dm-*)     dm_dev=$(basename "$var_dev") ;;
+esac
+if [ -n "$dm_dev" ]; then
+    slave=$(ls "/sys/block/$dm_dev/slaves/" 2>/dev/null | head -1)
+    blk_dev=${slave:+/dev/$slave}
+    : "${blk_dev:=$var_dev}"
+fi
 
-disk=/dev/$(lsblk -no PKNAME "$blk_dev")
+disk=/dev/$(lsblk -no PKNAME "$blk_dev" | head -1)
 part=$(printf '%s\n' "$blk_dev" | grep -oE '[0-9]+$')
 ptable=$(lsblk -dno PTTYPE "$disk")
 echo "grow-var: $var_dev (via $blk_dev) on $disk (partition $part, $ptable table)."
@@ -92,9 +101,25 @@ if [ "$blk_dev" != "$var_dev" ]; then
     fstype=$(lsblk -dno FSTYPE "$blk_dev")
     case "$fstype" in
     crypto_LUKS)
-        dm_name=${var_dev#/dev/mapper/}
-        echo "grow-var: resizing LUKS container $dm_name to fill partition."
-        cryptsetup resize "$dm_name"
+        case "$var_dev" in
+        /dev/mapper/*) dm_name=${var_dev#/dev/mapper/} ;;
+        *) dm_name=$(dmsetup info "$var_dev" 2>/dev/null | awk '/Name:/ {print $2}') ;;
+        esac
+        # cryptsetup resize requires the LUKS key to update header metadata.
+        # After switch_root the trusted key is no longer in the keyring, so
+        # resize cannot happen here.  The initramfs (cryptsetup-var.sh) already
+        # handles LUKS resize when it detects partition_sectors > dm_sectors on
+        # the next boot — with the key still available at that point.
+        data_offset=$(dmsetup table "$dm_name" | awk '{print $8}')
+        expected_dm=$(( $(blockdev --getsz "$blk_dev") - data_offset ))
+        dm_sectors=$(blockdev --getsz "$var_dev")
+        if [ "$dm_sectors" -lt "$expected_dm" ]; then
+            echo "grow-var: LUKS container ($dm_sectors sectors) < partition ($expected_dm sectors)."
+            echo "grow-var: partition extended — cryptsetup-var.sh will resize LUKS + btrfs on next boot."
+            echo "grow-var: reboot to complete resize."
+            exit 0
+        fi
+        echo "grow-var: LUKS container already at full size ($dm_sectors sectors)."
         ;;
     *)
         echo "grow-var: dm layer fstype '$fstype' — skipping intermediate resize." >&2

--- a/extensions/dev/overlays/base/usr/bin/avocado-grow-var
+++ b/extensions/dev/overlays/base/usr/bin/avocado-grow-var
@@ -1,8 +1,13 @@
 #!/bin/sh
-# Grow the /var partition to fill its parent disk, then expand the btrfs
-# filesystem inside it. Target-agnostic: discovers the var device, parent
-# disk, and partition number at runtime so the same script works for
-# mmcblk*, nvme*, sd*, etc.
+# Grow the /var partition to fill its parent disk, then expand any
+# intermediate device-mapper layer and the btrfs filesystem inside it.
+# Target-agnostic: discovers the var device, parent disk, and partition
+# number at runtime so the same script works for mmcblk*, nvme*, sd*, etc.
+#
+# Supports plain btrfs-on-partition and LUKS-encrypted /var.  For LUKS the
+# sequence is: grow disk partition → inform kernel → cryptsetup resize →
+# btrfs resize.  Other dm setups are handled by resolving the underlying
+# block partition for the GPT/MBR work; the dm layer is left to the caller.
 #
 # Guarded by /var/lib/avocado/.resized-var so it runs at most once per
 # install. Invoked by avocado-grow-var.service (oneshot) from the dev
@@ -17,10 +22,19 @@ if [ -e "$marker" ]; then
 fi
 
 var_dev=$(findmnt -no SOURCE /var)
-disk=/dev/$(lsblk -no PKNAME "$var_dev")
-part=$(printf '%s\n' "$var_dev" | grep -oE '[0-9]+$')
+
+# Resolve through any device-mapper layer (e.g. LUKS) to the real block
+# partition.  lsblk -l lists all devices in the dependency tree of the given
+# device; selecting the first entry typed "part" gives the underlying
+# partition regardless of how many dm layers sit above it.
+blk_dev=$(lsblk -lno NAME,TYPE "$var_dev" 2>/dev/null \
+          | awk '$2 == "part" { print "/dev/" $1; exit }')
+: "${blk_dev:=$var_dev}"
+
+disk=/dev/$(lsblk -no PKNAME "$blk_dev")
+part=$(printf '%s\n' "$blk_dev" | grep -oE '[0-9]+$')
 ptable=$(lsblk -dno PTTYPE "$disk")
-echo "grow-var: $var_dev on $disk (partition $part, $ptable table)."
+echo "grow-var: $var_dev (via $blk_dev) on $disk (partition $part, $ptable table)."
 
 case "$ptable" in
 gpt)
@@ -69,6 +83,24 @@ esac
 # partition as long as the start sector and identity are unchanged.
 echo "grow-var: informing kernel of new size for partition $part."
 partx --update --nr "$part" "$disk"
+
+# If /var sits behind a device-mapper layer, resize it before resizing
+# the filesystem.  Currently handles crypto_LUKS; other dm types are
+# skipped with a warning (the filesystem resize below may still succeed
+# if the dm layer auto-expands or was pre-sized).
+if [ "$blk_dev" != "$var_dev" ]; then
+    fstype=$(lsblk -dno FSTYPE "$blk_dev")
+    case "$fstype" in
+    crypto_LUKS)
+        dm_name=${var_dev#/dev/mapper/}
+        echo "grow-var: resizing LUKS container $dm_name to fill partition."
+        cryptsetup resize "$dm_name"
+        ;;
+    *)
+        echo "grow-var: dm layer fstype '$fstype' — skipping intermediate resize." >&2
+        ;;
+    esac
+fi
 
 echo "grow-var: resizing btrfs on /var to max."
 btrfs filesystem resize max /var


### PR DESCRIPTION
avocado-grow-var fails when /var is LUKS-encrypted because findmnt returns /dev/mapper/<name> instead of a block partition. Two problems:

  1. lsblk -no PKNAME /dev/mapper/<name> returns empty — disk resolves to "/dev/" and subsequent commands fail.
  2. grep -oE '[0-9]+$' on "/dev/mapper/var-crypt" finds no match, causing set -eu to exit with code 1 before any work is done.

Fix: resolve the underlying block partition before all disk/partition operations by walking the lsblk dependency tree of the source device and selecting the first entry typed "part":

  blk_dev=$(lsblk -lno NAME,TYPE "$var_dev" | awk '$2=="part"{...}')

This is a no-op for plain (unencrypted) /var — lsblk returns only the partition itself, so blk_dev == var_dev and all existing paths are unchanged.

For LUKS, add an intermediate cryptsetup resize step between partx and btrfs resize so the full chain is honoured:

  sgdisk/sfdisk -> partx -> cryptsetup resize -> btrfs resize

The LUKS case is detected by checking the fstype of the resolved block partition (crypto_LUKS). Other dm setups (LVM, dm-verity, etc.) fall through to a warning and proceed directly to btrfs resize, which may succeed if the dm layer auto-expands.

Tested on imx8mp-evk with LUKS2/btrfs /var encrypted via NXP CAAM trusted keys. Without this fix the service fails on every boot and the var partition never grows beyond the provisioned image size.

```
root@avocado-imx8mp-evk:~# df -h /var
Filesystem      Size  Used Avail Use% Mounted on
/dev/dm-0        29G  414M   28G   2% /var
```