### PR TITLE
Add a coreutils extension for bench boards

### DIFF
--- a/extensions/coreutils/avocado.yaml
+++ b/extensions/coreutils/avocado.yaml
@@ -1,0 +1,58 @@
+supported_targets: '*'
+
+distro:
+  release: 2024
+  channel: edge
+
+extensions:
+  avocado-ext-coreutils:
+    # sysext only. Every package here lands under /usr, and none of them needs
+    # a unit or anything in /etc, so there is nothing for a confext to carry.
+    types:
+      - sysext
+    version: 1.0.0
+    release: r0
+    summary: GNU userland in place of the BusyBox applets
+    description: >
+      Replaces the BusyBox applets with their GNU equivalents on a bench board.
+      A minimal Avocado image gets ls, grep, sed, find, ps and the rest from
+      BusyBox, whose flags and output are a subset of GNU's and differ in ways
+      that break otherwise-correct commands. That is fine for a shipped image
+      and costly on a board someone - or an agent - is driving interactively.
+      Development only.
+
+    packages:
+      # The applets people actually trip over. coreutils alone is not enough:
+      # find, grep, sed and awk are separate BusyBox applets with their own
+      # divergences, and each has its own GNU package.
+      coreutils: '*'
+      findutils: '*'
+      grep: '*'
+      sed: '*'
+      gawk: '*'
+      diffutils: '*'
+      procps: '*'
+      tar: '*'
+      which: '*'
+      file: '*'
+      # A real shell, not ash. BusyBox ash lacks arrays, `local -n`, process
+      # substitution and `[[ =~ ]]`, so scripts written against bash fail on it
+      # in ways that read as logic bugs rather than as a missing feature.
+      bash: '*'
+
+sdk:
+  image: docker.io/avocadolinux/sdk:{{ avocado.distro.release }}-{{ avocado.distro.channel }}
+
+  packages:
+    # avocado-cli emits an erofs formatter call for every extension whose type
+    # is erofs (commands/ext/image.rs:921) without declaring the tool it needs,
+    # so on a clean SDK the content builds and the image step then dies on
+    # command-not-found.
+    #
+    # avocado-debt: per-project workaround for a CLI/SDK gap. Ceiling:
+    # one project at a time - most of the in-tree bsp/ and extensions/ configs
+    # still lack this and fail identically the moment someone builds them on a
+    # clean SDK. Upgrade trigger: avocado-cli declares the formatter alongside
+    # the call site, or the SDK image ships it - then delete this block rather
+    # than copying it to the next config.
+    nativesdk-erofs-utils: '*'


### PR DESCRIPTION
## Problem

A minimal Avocado image gets `ls`, `grep`, `sed`, `find`, `ps` and the rest from BusyBox, whose flags and output are a subset of GNU's. A command that is correct on any other Linux fails on the board, and the error rarely names the applet as the narrower one.

## Solution

A sysext-only extension installing the GNU packages over the BusyBox applets. OE's `update-alternatives` does the switching (`/usr/bin/ls` becomes `ls.coreutils`), and because a sysext overlays `/usr`, the extension shadows the BusyBox symlinks without modifying the base image.

`coreutils` alone would not cover it: `find`, `grep`, `sed` and `awk` are separate BusyBox applets with their own divergences, so each needs its own GNU package. `bash` is included because ash silently lacks arrays, process substitution and `[[ =~ ]]`, absences that read as logic bugs rather than a missing shell feature.

## Key changes

- New `extensions/coreutils/avocado.yaml` declaring `avocado-ext-coreutils`, sysext only, `supported_targets: '*'`
- Installs coreutils, findutils, grep, sed, gawk, diffutils, procps, tar, which, file and bash
- Declares `nativesdk-erofs-utils` for the SDK, with a marker naming the gap it works around

## Reviewer notes

- **Development only**, and opt-in. No existing project changes behaviour.
- **Verified on hardware.** Flashed to a Jetson Orin Nano dev kit (P3767-0005) as part of a fixture declaring this extension: `ls --version` reports `ls (GNU coreutils) 9.4`, and `readlink -f /usr/bin/ls` resolves to `/usr/bin/ls.coreutils`.
- The `nativesdk-erofs-utils` block is a workaround, not a fix. `avocado-cli` emits the erofs formatter call at `commands/ext/image.rs:921` without declaring the tool it needs, so on a clean SDK the extension content builds and the image step then dies on `command-not-found`. Most in-tree `bsp/` and `extensions/` configs carry the same latent gap; the marker names the condition that should retire this block rather than have it copied to the next config.
