### PR TITLE
Declare the erofs formatter for the SDK in two configs

### DIFF
--- a/bsp/jetson-orin-nano-devkit/avocado.yaml
+++ b/bsp/jetson-orin-nano-devkit/avocado.yaml
@@ -200,3 +200,17 @@ extensions:
 
 sdk:
   image: docker.io/avocadolinux/sdk:{{ avocado.distro.release }}-{{ avocado.distro.channel }}
+
+  packages:
+    # avocado-cli emits an erofs formatter call for every extension whose type
+    # is erofs (commands/ext/image.rs:921) without declaring the tool it needs,
+    # so on a clean SDK the content builds and the image step then dies on
+    # command-not-found.
+    #
+    # avocado-debt: per-project workaround for a CLI/SDK gap. Ceiling:
+    # one project at a time - 42 of the 46 in-tree bsp/ and extensions/ configs
+    # still lack this and fail identically the moment someone builds them on a
+    # clean SDK. Upgrade trigger: avocado-cli declares the formatter alongside
+    # the call site, or the SDK image ships it - then delete this block rather
+    # than copying it to a 44th config.
+    nativesdk-erofs-utils: '*'

--- a/extensions/dev/avocado.yaml
+++ b/extensions/dev/avocado.yaml
@@ -55,3 +55,17 @@ extensions:
 
 sdk:
   image: docker.io/avocadolinux/sdk:{{ avocado.distro.release }}-{{ avocado.distro.channel }}
+
+  packages:
+    # avocado-cli emits an erofs formatter call for every extension whose type
+    # is erofs (commands/ext/image.rs:921) without declaring the tool it needs,
+    # so on a clean SDK the content builds and the image step then dies on
+    # command-not-found.
+    #
+    # avocado-debt: per-project workaround for a CLI/SDK gap. Ceiling:
+    # one project at a time - most of the in-tree bsp/ and extensions/ configs
+    # still lack this and fail identically the moment someone builds them on a
+    # clean SDK. Upgrade trigger: avocado-cli declares the formatter alongside
+    # the call site, or the SDK image ships it - then delete this block rather
+    # than copying it to the next config.
+    nativesdk-erofs-utils: '*'


### PR DESCRIPTION
## Problem

Building either of these two projects against a freshly pulled SDK fails at the image step with `mkfs.erofs: command not found`, after dependency resolution and the content build have both already succeeded. The failure reads as a broken BSP or a broken extension; it is a missing SDK package.

`avocado-cli` emits the erofs formatter call for every extension whose type is erofs (`commands/ext/image.rs:921`) but never declares the tool that call needs, so nothing pulls it into the SDK container.

## Solution

Declare `nativesdk-erofs-utils` in each affected project's `sdk.packages`. This is the wrong layer and the commits say so: each block carries an `avocado-debt:` marker naming its ceiling and the condition that should retire it.

The alternative was to leave both projects unbuildable on a clean SDK until the CLI gains the declaration, which blocks hardware work on a fix in another repo.

## Key changes

- `bsp/jetson-orin-nano-devkit/avocado.yaml` - declare `nativesdk-erofs-utils`
- `extensions/dev/avocado.yaml` - same

## Reviewer notes

- **Only the two configs actually built are touched.** 42 of the 46 in-tree `bsp/` and `extensions/` configs carry the same latent gap and will fail identically the first time anyone builds them on a clean SDK. Patching all of them would spread the workaround and remove the pressure to fix it where the call site lives, so each is left to be fixed when it is next built — with the marker pointing at the real fix.
- The four configs that already declare this (`hello`, `docker`, `coreutils`, and now these) are not independent precedent for the pattern being correct. All were added for this same failure.
- The proper fix is `avocado-cli` declaring the formatter alongside the call site, or the SDK image shipping it. When that lands, these blocks should be deleted rather than copied to a further config.
- Verified: with these declarations, `avocado build -e avocado-bsp-jetson-orin-nano-devkit` and `avocado build -e avocado-ext-dev` both complete and package. Without them, both stop at `mkfs.erofs: command not found` with no other error in the run.
